### PR TITLE
Fix incorrect text at end of chapter 6

### DIFF
--- a/book/src/chapter_6.md
+++ b/book/src/chapter_6.md
@@ -337,7 +337,7 @@ impl<'a> System<'a> for MonsterAI {
 }
 ```
 
-We also need to give the player a name; we've explicitly included names in the AI's join, so we better be sure that the player has one! Otherwise, the AI will ignore the player altogether. In `main.rs`, we'll include one in the `Player` creation:
+While we're at it, let's go ahead and give the player a name, too. In `main.rs`, we'll include one in the `Player` creation:
 
 ```rust
 gs.ecs


### PR DESCRIPTION
Because the monster AI's `join` includes the `Monster` tag, the player is being excluded from this loop whether they have a `Name` or not. It's not relevant either way to the logic of the AI anyway, as it gets the player's position via the `Point` resource created earlier in the chapter.